### PR TITLE
[FIX] Change the grid to 2 columns instead of 3 for categories.

### DIFF
--- a/app/[category]/page.tsx
+++ b/app/[category]/page.tsx
@@ -42,7 +42,7 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
   return (
     <>
       <PageBanner title={category.name} subtitle={category.description} />
-      <PageGrid className="grow h-full">
+      <PageGrid className="grow lg:grid-cols-2">
         {hooks.map((hook, index) => (
           <HookCard
             key={hook.name}

--- a/components/hook-card.tsx
+++ b/components/hook-card.tsx
@@ -14,7 +14,7 @@ type HookCardProps = {
 
 export function HookCard({ name, description, children }: HookCardProps) {
   return (
-    <Card className="relative max-h-[200px]">
+    <Card className="relative">
       <CardHeader className="border-b">
         <CardTitle>{name.replace('-demo', '')}</CardTitle>
         <CardDescription>{description}</CardDescription>

--- a/components/page-grid.tsx
+++ b/components/page-grid.tsx
@@ -9,8 +9,8 @@ export function PageGrid({ children, className }: PageGridProps) {
   return (
     <section
       className={cn(
-        'relative w-full',
-        'grid gap-x-6 gap-y-6 grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
+        'relative size-full',
+        'grid gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
         className,
       )}
     >


### PR DESCRIPTION
Change the layout to 2 columns in the category page:

![image](https://github.com/user-attachments/assets/36b0752c-f2b5-4779-986e-e293f43417ca)
